### PR TITLE
Replace Leap with Slowroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ sudo zypper addrepo https://download.opensuse.org/repositories/home:/Rabbit95/op
 sudo zypper --gpg-auto-import-keys install -y faugus-launcher
 ```
 ```
-# Leap 15.5
-sudo zypper addrepo https://download.opensuse.org/repositories/home:/Rabbit95/openSUSE_Leap_15.5/ home:Rabbit95
+# Slowroll
+sudo zypper addrepo https://download.opensuse.org/repositories/home:/Rabbit95/openSUSE_Slowroll/ home:Rabbit95
 sudo zypper --gpg-auto-import-keys install -y faugus-launcher
 ```
 ```


### PR DESCRIPTION
There are compilation problems with umu-launcher for months and I don't use Leap, So won't support it.