### PR TITLE
Update readme.md: Heavily recommend the Flatpak for Bazzite

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ sudo dnf -y install faugus-launcher
 ```
 
 ## Bazzite (Copr)
+[Flatpak](#flatpak) is the preferred app format for Bazzite. Use of rpm-ostree is heavily discouraged.
 ```
 sudo dnf5 -y copr enable faugus/faugus-launcher
 sudo rpm-ostree -y install faugus-launcher
@@ -55,6 +56,7 @@ sudo zypper addrepo https://download.opensuse.org/repositories/home:/Rabbit95/op
 sudo zypper --gpg-auto-import-keys install -y faugus-launcher
 ```
 
+<a id="flatpak"></a>
 ## [Flatpak](https://flathub.org/apps/io.github.Faugus.faugus-launcher)
 ### Installation:
 ```


### PR DESCRIPTION
As is mentioned in https://docs.bazzite.gg/, `rpm-ostree` should only be used "as a last resort" for installing software on Bazzite. This pull request adds a section to the README.md that explains this and (upon click) sends the user to the flatpak installation section.