### PR TITLE
Fix quotes to make launchable

### DIFF
--- a/faugus_launcher.py
+++ b/faugus_launcher.py
@@ -6815,9 +6815,9 @@ class CreateShortcut(Gtk.Window):
             if lossless_flow:
                 command_parts.append(f"LSFG_FLOW_SCALE={lossless_flow/100}")
             if lossless_performance:
-                command_parts.append(f"LSFG_PERFORMANCE_MODE={1 if lossless_performance == "true" else 0}")
+                command_parts.append(f"LSFG_PERFORMANCE_MODE={1 if lossless_performance == 'true' else 0}")
             if lossless_hdr:
-                command_parts.append(f"LSFG_HDR_MODE={1 if lossless_hdr == "true" else 0}")
+                command_parts.append(f"LSFG_HDR_MODE={1 if lossless_hdr == 'true' else 0}")
 
         # Add the fixed command and remaining arguments
         command_parts.append(f"'{umu_run}'")


### PR DESCRIPTION
Change some "true" statements to have single quotes because having double quotes in double quotes may cause failure to launch.
This works to make the Debian version successfully launch on Debian 12