### PR TITLE
Fix Software store not fully recognizing Faugus Launcher system installation

### DIFF
--- a/data/faugus-launcher.metainfo.xml
+++ b/data/faugus-launcher.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>faugus-launcher</id>
+  <id>faugus-launcher.desktop</id>
   <name>Faugus Launcher</name>
   <developer_name>Faugus</developer_name>
   <summary>A simple and lightweight app for running games using UMU-Launcher</summary>


### PR DESCRIPTION
added missing characteristic to application ID so xml file attaches to launcher install properly. as is, there is no reported install size, the "open" button on the store page doesn't work, and neither uninstall buttons work. by default the details option after right clicking the launcher brings you to the flatpak page even when installed as an rpm. This change fixes those 4 issues and completes the system integration for any future packages

Before:
<img width="586" height="101" alt="Screenshot From 2025-11-07 20-47-45" src="https://github.com/user-attachments/assets/d85099ed-ec99-4503-924b-faa0acf42142" />
<img width="1250" height="1105" alt="image" src="https://github.com/user-attachments/assets/e7c2df1f-7678-4d5b-b67e-84259a545575" />

After:
<img width="582" height="93" alt="Screenshot From 2025-11-07 20-51-07" src="https://github.com/user-attachments/assets/43ecb3ba-18c4-4c29-8ecf-53ceef2ae996" />
<img width="1250" height="1092" alt="Screenshot From 2025-11-07 20-42-40" src="https://github.com/user-attachments/assets/7eb433e2-c9ba-4ec7-9a46-7d5fdc575dfb" />
