### PR TITLE
Fix: allow protonfixes for steam games

### DIFF
--- a/faugus_run.py
+++ b/faugus_run.py
@@ -118,7 +118,7 @@ class FaugusRun:
                     set_env("PROTONPATH", f"{self.default_runner}")
 
         if os.environ.get("GAMEID") != "winetricks-gui":
-            if "umu" not in os.environ.get("GAMEID", ""):
+            if "umu" not in os.environ.get("GAMEID", "") and not (os.environ.get("GAMEID", "").isnumeric()):
                 set_env("PROTONFIXES_DISABLE", "1")
 
         protonpath = os.environ.get("PROTONPATH")


### PR DESCRIPTION
This pr fixes an issue where UMU only applies protonfixes if GAMEID contains umu, making it impossible to use protonfixes for steam games (For steam games, GAMEID is numeric only, which doesn't contain the word umu)