### PR TITLE
Improve search performance in large libraries

### DIFF
--- a/faugus_launcher.py
+++ b/faugus_launcher.py
@@ -1504,23 +1504,19 @@ class Main(Gtk.Window):
 
     def on_search_changed(self, entry):
         search_text = entry.get_text().lower()
-        self.filtered_games = [game for game in self.games if search_text in game.title.lower()]
+        first_visible = None
 
         for child in self.flowbox.get_children():
-            self.flowbox.remove(child)
+            game = child.game
+            is_match = search_text in game.title.lower()
 
-        if self.filtered_games:
-            for game in self.filtered_games:
-                self.add_item_list(game)
+            child.set_visible(is_match)
+            if is_match and first_visible is None:
+                first_visible = child
 
-            first_child = self.flowbox.get_children()[0]
-            self.flowbox.select_child(first_child)
-            self.on_item_selected(self.flowbox, first_child)
-
-        else:
-            pass
-
-        self.flowbox.show_all()
+        if first_visible:
+            self.flowbox.select_child(first_visible)
+            self.on_item_selected(self.flowbox, first_visible)
 
     def on_item_selected(self, flowbox, child):
         if child is not None:


### PR DESCRIPTION
The current implementation of `on_search_changed(self, entry)` removes every child from the flowbox and repopulates it with matching flowbox children with every keystroke in the search bar. The performance cost of this isn't very noticeable in smaller game libraries, but in libraries pushing 100+ games, typing into the search bar causes noticeable hitches and unresponsiveness.

My solution to this is to toggle the visibility of flowbox children with `set_visible()` instead of destroying and recreating them on every keystroke. This makes the game search bar much more responsive, especially when searching through large game libraries.

Part of my solution involves another minor optimization, which is to have each flowbox child store a reference to its associated `Game` object. In the current implementation, a flowbox child must iterate over every `Game` object when it wants to know what game it's associated with. I replace several of these O(n) time iterations with accesses to the `Game` object via reference in O(1) time.