### PR TITLE
Fix LSFG_PERFORMANCE_MODE and LSFG_HDR_MODE always set to 0

### DIFF
--- a/faugus/shortcut.py
+++ b/faugus/shortcut.py
@@ -677,9 +677,13 @@ class CreateShortcut(Gtk.Window):
             if lossless_flow:
                 command_parts.append(f"LSFG_FLOW_SCALE={lossless_flow/100}")
             if lossless_performance:
-                command_parts.append(f"LSFG_PERFORMANCE_MODE={1 if lossless_performance == 'true' else 0}")
+                command_parts.append("LSFG_PERFORMANCE_MODE=1")
+            else:
+                command_parts.append("LSFG_PERFORMANCE_MODE=0")
             if lossless_hdr:
-                command_parts.append(f"LSFG_HDR_MODE={1 if lossless_hdr == 'true' else 0}")
+                command_parts.append("LSFG_HDR_MODE=1")
+            else:
+                command_parts.append("LSFG_HDR_MODE=0")
         if gamemode:
             command_parts.append("gamemoderun")
         if mangohud:

--- a/faugus_run.py
+++ b/faugus_run.py
@@ -711,9 +711,13 @@ def build_launch_command(game):
         if lossless_flow:
             command_parts.append(f"LSFG_FLOW_SCALE={lossless_flow/100}")
         if lossless_performance:
-            command_parts.append(f"LSFG_PERFORMANCE_MODE={1 if lossless_performance == 'true' else 0}")
+            command_parts.append("LSFG_PERFORMANCE_MODE=1")
+        else:
+            command_parts.append("LSFG_PERFORMANCE_MODE=0")
         if lossless_hdr:
-            command_parts.append(f"LSFG_HDR_MODE={1 if lossless_hdr == 'true' else 0}")
+            command_parts.append("LSFG_HDR_MODE=1")
+        else:
+            command_parts.append("LSFG_HDR_MODE=0")
     if launch_arguments:
         command_parts.append(launch_arguments)
     if gamemode:


### PR DESCRIPTION
Fix logic bug where `LSFG_PERFORMANCE_MODE` and `LSFG_HDR_MODE` were always set to `0`.

The code first converted the checkbox values to integers (1/0), but
later compared them to the string `true`, which always evaluated to
`false`. As a result, both environment variables were always set to `0`.

This patch simplifies the logic and explicitly sets:

- LSFG_* = 1 when enabled
- LSFG_* = 0 when disabled

This avoids string comparisons and ensures consistent behavior.