### PR TITLE
Add missing Flatpak quirk to Flathub description

### DIFF
--- a/data/io.github.Faugus.faugus-launcher.metainfo.xml
+++ b/data/io.github.Faugus.faugus-launcher.metainfo.xml
@@ -41,7 +41,7 @@
       <li>The 'stop' button won't close games.</li>
       <li>Gamescope doesn't work.</li>
       <li>It may not use the system theme in some DEs.</li>
-      <li>Game windows will use the Faugus Launcher icon when running instead of their intended icon</li>
+      <li>Game windows will use the Faugus Launcher icon instead of their intended icon</li>
     </ul>
   </description>
   <categories>

--- a/data/io.github.Faugus.faugus-launcher.metainfo.xml
+++ b/data/io.github.Faugus.faugus-launcher.metainfo.xml
@@ -41,6 +41,7 @@
       <li>The 'stop' button won't close games.</li>
       <li>Gamescope doesn't work.</li>
       <li>It may not use the system theme in some DEs.</li>
+      <li>Game windows will use the Faugus Launcher icon when running instead of their intended icon</li>
     </ul>
   </description>
   <categories>

--- a/data/io.github.Faugus.faugus-launcher.metainfo.xml
+++ b/data/io.github.Faugus.faugus-launcher.metainfo.xml
@@ -41,7 +41,7 @@
       <li>The 'stop' button won't close games.</li>
       <li>Gamescope doesn't work.</li>
       <li>It may not use the system theme in some DEs.</li>
-      <li>Game windows will use the Faugus Launcher icon instead of their intended icon</li>
+      <li>Game windows will use the Faugus Launcher icon instead of their intended icon.</li>
     </ul>
   </description>
   <categories>


### PR DESCRIPTION
Multiple people mentioned to me struggling with getting proper app icons to display, which was instantly recognizable as a flatpak caveat. This info was missing from the app description, leading to confusion for users less familiar with the limitations of flatpak, so I've gone ahead and added it in to prevent further issue.