### PR TITLE
remove unused argument start_process function

### DIFF
--- a/faugus_run.py
+++ b/faugus_run.py
@@ -79,7 +79,7 @@ class FaugusRun:
 
     def run(self):
         def run_process():
-            self.start_process(self.command)
+            self.start_process()
 
         self.process_thread = Thread(target=run_process)
 
@@ -93,7 +93,7 @@ class FaugusRun:
         self.process_thread.join()
         sys.exit(0)
 
-    def start_process(self, command):
+    def start_process(self):
         if self.show_donate:
             if self.playtime >= 7200:
                 current_month = GLib.DateTime.new_now_local().format("%Y-%m")


### PR DESCRIPTION
noticed start_process had an unused command argument, so I removed it. Left all GTK/GLib callbacks alone since their parameters are required for signals. Nothing else changes.