### PR TITLE
Correctly detect EA App version

### DIFF
--- a/faugus/ea_fix.py
+++ b/faugus/ea_fix.py
@@ -1,0 +1,41 @@
+import json
+import os
+
+from faugus.path_manager import *
+
+games_json = PathManager.user_config('faugus-launcher/games.json')
+
+def update_ea_path(prefix):
+    new_path = f"{prefix}/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EALauncher.exe"
+
+    try:
+        with open(os.path.join(prefix, "drive_c", "ProgramData", "EA Desktop", "machine.ini"), "r") as machine_ini:
+            for l in machine_ini.readlines():
+                if "machine.telemetry.updatestats" in l:
+                    launcher_version = json.loads(l.split("=")[1])["version"]
+                    new_path = f"{prefix}/drive_c/Program Files/Electronic Arts/EA Desktop/{launcher_version}/EA Desktop/EALauncher.exe"
+                    break
+    except FileNotFoundError:
+        print("machine.ini not found")
+    except KeyError:
+        print("version not found in updatestats")
+
+    if os.path.exists(games_json):
+        try:
+            with open(games_json, "r", encoding="utf-8") as f:
+                games = json.load(f)
+        except (json.JSONDecodeError, FileNotFoundError):
+            games = []
+
+        changed = False
+
+        for game in games:
+            if "EALauncher.exe" in game.get("path", ""):
+                game["path"] = new_path
+                changed = True
+
+        if changed:
+            with open(games_json, "w", encoding="utf-8") as f:
+                json.dump(games, f, indent=4, ensure_ascii=False)
+
+    return new_path

--- a/faugus/launcher.py
+++ b/faugus/launcher.py
@@ -10,6 +10,7 @@ import gi
 import vdf
 import signal
 import gettext
+import os
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
@@ -93,6 +94,19 @@ faugus_backup = False
 
 os.makedirs(faugus_launcher_share_dir, exist_ok=True)
 os.makedirs(faugus_launcher_dir, exist_ok=True)
+
+def get_ea_app_path(prefix):
+    try:
+        with open(os.path.join(prefix, "drive_c", "ProgramData", "EA Desktop", "machine.ini"), "r") as machine_ini:
+            for l in machine_ini.readlines():
+                if "machine.telemetry.updatestats" in l:
+                    launcher_version = json.loads(l.split("=")[1])["version"]
+                    return f"{prefix}/drive_c/Program Files/Electronic Arts/EA Desktop/{launcher_version}/EA Desktop/EALauncher.exe"
+    except FileNotFoundError:
+        print("machine.ini not found")
+    except KeyError:
+        print("version not found in updatestats")
+    return f"{prefix}/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EALauncher.exe"
 
 def get_desktop_dir():
     try:
@@ -1459,6 +1473,9 @@ class Main(Gtk.ApplicationWindow):
                     if not self.show_hidden and game.hidden:
                         continue
 
+                    if game.gameid == "ea-app":
+                        game.path = get_ea_app_path(game.prefix)
+
                     self.games.append(game)
 
                 self.games = sorted(self.games, key=lambda x: x.title.lower())
@@ -2186,7 +2203,7 @@ class Main(Gtk.ApplicationWindow):
             if launcher_id == "battle":
                 path = f"{prefix}/drive_c/Program Files (x86)/Battle.net/Battle.net.exe"
             if launcher_id == "ea":
-                path = f"{prefix}/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EALauncher.exe"
+                path = get_ea_app_path(prefix)
             if launcher_id == "epic":
                 path = f"{prefix}/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe"
             if launcher_id == "ubisoft":
@@ -2331,6 +2348,10 @@ class Main(Gtk.ApplicationWindow):
                     print(f"Error reading the JSON file: {e}")
 
             games.append(game_info)
+
+            for game in games:
+                if game["gameid"] == "ea-app":
+                    game["path"] = get_ea_app_path(game["prefix"])
 
             self.backup_games()
 
@@ -2480,7 +2501,7 @@ class Main(Gtk.ApplicationWindow):
     def on_button_finish_install_clicked(self):
         self.on_button_kill_clicked(widget)
 
-    def monitor_process(self, processo, game, desktop_shortcut_state, appmenu_shortcut_state, steam_shortcut_state, icon_temp, icon_final, title):
+    def monitor_process(self, processo, game, desktop_shortcut_state, appmenu_shortcut_state, steam_shortcut_state, icon_temp, icon_final, title, launcher):
         retcode = processo.poll()
 
         if retcode is not None:
@@ -2491,6 +2512,9 @@ class Main(Gtk.ApplicationWindow):
             self.box_main.remove(self.box_launcher)
             self.box_launcher.destroy()
             self.box_main.show_all()
+
+            if launcher == "ea":
+                game.path = get_ea_app_path(game.prefix)
 
             if os.path.exists(game.path):
                 print(f"{title} installed.")
@@ -2591,7 +2615,7 @@ class Main(Gtk.ApplicationWindow):
                 self.bar_download.set_visible(False)
                 self.label_download2.set_visible(True)
                 processo = subprocess.Popen([sys.executable, "-m", "faugus.runner", command])
-                GLib.timeout_add(100, self.monitor_process, processo, game, desktop_shortcut_state, appmenu_shortcut_state, steam_shortcut_state, icon_temp, icon_final, title)
+                GLib.timeout_add(100, self.monitor_process, processo, game, desktop_shortcut_state, appmenu_shortcut_state, steam_shortcut_state, icon_temp, icon_final, title, launcher)
 
             threading.Thread(target=start_download).start()
 
@@ -2950,7 +2974,7 @@ class Main(Gtk.ApplicationWindow):
                 game_data = {
                     "gameid": game.gameid,
                     "title": game.title,
-                    "path": game.path,
+                    "path": get_ea_app_path(game.prefix) if game.gameid == "ea-app" else game.path,
                     "prefix": game.prefix,
                     "launch_arguments": game.launch_arguments,
                     "game_arguments": game.game_arguments,
@@ -5822,8 +5846,7 @@ class AddGame(Gtk.Dialog):
             self.checkbox_prevent_sleep.set_visible(True)
             self.entry_launch_arguments.set_text("PROTON_ENABLE_WAYLAND=0")
             self.entry_title.set_text(self.combobox_launcher.get_active_text())
-            self.entry_path.set_text(
-                f"{self.entry_prefix.get_text()}/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EALauncher.exe")
+            self.entry_path.set_text(get_ea_app_path(self.entry_prefix.get_text()))
             shutil.copyfile(ea_icon, os.path.expanduser(self.icon_temp))
             pixbuf = GdkPixbuf.Pixbuf.new_from_file(self.icon_temp)
             scaled_pixbuf = pixbuf.scale_simple(50, 50, GdkPixbuf.InterpType.BILINEAR)
@@ -5954,7 +5977,7 @@ class AddGame(Gtk.Dialog):
         self.combobox_launcher.append("linux", _("Linux Game"))
         self.combobox_launcher.append("steam", _("Steam Game"))
         self.combobox_launcher.append("battle", "Battle.net")
-        #self.combobox_launcher.append("ea", "EA App")
+        self.combobox_launcher.append("ea", "EA App")
         self.combobox_launcher.append("epic", "Epic Games")
         self.combobox_launcher.append("rockstar", "Rockstar Launcher")
         self.combobox_launcher.append("ubisoft", "Ubisoft Connect")

--- a/faugus/launcher.py
+++ b/faugus/launcher.py
@@ -10,7 +10,6 @@ import gi
 import vdf
 import signal
 import gettext
-import os
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
@@ -21,6 +20,7 @@ from PIL import Image
 from faugus.config_manager import *
 from faugus.dark_theme import *
 from faugus.steam_setup import *
+from faugus.ea_fix import *
 
 VERSION = "1.17.4"
 IS_FLATPAK = 'FLATPAK_ID' in os.environ or os.path.exists('/.flatpak-info')
@@ -94,19 +94,6 @@ faugus_backup = False
 
 os.makedirs(faugus_launcher_share_dir, exist_ok=True)
 os.makedirs(faugus_launcher_dir, exist_ok=True)
-
-def get_ea_app_path(prefix):
-    try:
-        with open(os.path.join(prefix, "drive_c", "ProgramData", "EA Desktop", "machine.ini"), "r") as machine_ini:
-            for l in machine_ini.readlines():
-                if "machine.telemetry.updatestats" in l:
-                    launcher_version = json.loads(l.split("=")[1])["version"]
-                    return f"{prefix}/drive_c/Program Files/Electronic Arts/EA Desktop/{launcher_version}/EA Desktop/EALauncher.exe"
-    except FileNotFoundError:
-        print("machine.ini not found")
-    except KeyError:
-        print("version not found in updatestats")
-    return f"{prefix}/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EALauncher.exe"
 
 def get_desktop_dir():
     try:
@@ -1473,9 +1460,6 @@ class Main(Gtk.ApplicationWindow):
                     if not self.show_hidden and game.hidden:
                         continue
 
-                    if game.gameid == "ea-app":
-                        game.path = get_ea_app_path(game.prefix)
-
                     self.games.append(game)
 
                 self.games = sorted(self.games, key=lambda x: x.title.lower())
@@ -2203,7 +2187,7 @@ class Main(Gtk.ApplicationWindow):
             if launcher_id == "battle":
                 path = f"{prefix}/drive_c/Program Files (x86)/Battle.net/Battle.net.exe"
             if launcher_id == "ea":
-                path = get_ea_app_path(prefix)
+                path = f"{prefix}/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EALauncher.exe"
             if launcher_id == "epic":
                 path = f"{prefix}/drive_c/Program Files/Epic Games/Launcher/Portal/Binaries/Win64/EpicGamesLauncher.exe"
             if launcher_id == "ubisoft":
@@ -2348,10 +2332,6 @@ class Main(Gtk.ApplicationWindow):
                     print(f"Error reading the JSON file: {e}")
 
             games.append(game_info)
-
-            for game in games:
-                if game["gameid"] == "ea-app":
-                    game["path"] = get_ea_app_path(game["prefix"])
 
             self.backup_games()
 
@@ -2501,7 +2481,7 @@ class Main(Gtk.ApplicationWindow):
     def on_button_finish_install_clicked(self):
         self.on_button_kill_clicked(widget)
 
-    def monitor_process(self, processo, game, desktop_shortcut_state, appmenu_shortcut_state, steam_shortcut_state, icon_temp, icon_final, title, launcher):
+    def monitor_process(self, processo, game, desktop_shortcut_state, appmenu_shortcut_state, steam_shortcut_state, icon_temp, icon_final, title):
         retcode = processo.poll()
 
         if retcode is not None:
@@ -2513,8 +2493,8 @@ class Main(Gtk.ApplicationWindow):
             self.box_launcher.destroy()
             self.box_main.show_all()
 
-            if launcher == "ea":
-                game.path = get_ea_app_path(game.prefix)
+            if game.gameid == "ea-app":
+                game.path = update_ea_path(game.prefix)
 
             if os.path.exists(game.path):
                 print(f"{title} installed.")
@@ -2615,7 +2595,7 @@ class Main(Gtk.ApplicationWindow):
                 self.bar_download.set_visible(False)
                 self.label_download2.set_visible(True)
                 processo = subprocess.Popen([sys.executable, "-m", "faugus.runner", command])
-                GLib.timeout_add(100, self.monitor_process, processo, game, desktop_shortcut_state, appmenu_shortcut_state, steam_shortcut_state, icon_temp, icon_final, title, launcher)
+                GLib.timeout_add(100, self.monitor_process, processo, game, desktop_shortcut_state, appmenu_shortcut_state, steam_shortcut_state, icon_temp, icon_final, title)
 
             threading.Thread(target=start_download).start()
 
@@ -2974,7 +2954,7 @@ class Main(Gtk.ApplicationWindow):
                 game_data = {
                     "gameid": game.gameid,
                     "title": game.title,
-                    "path": get_ea_app_path(game.prefix) if game.gameid == "ea-app" else game.path,
+                    "path": game.path,
                     "prefix": game.prefix,
                     "launch_arguments": game.launch_arguments,
                     "game_arguments": game.game_arguments,
@@ -5846,7 +5826,8 @@ class AddGame(Gtk.Dialog):
             self.checkbox_prevent_sleep.set_visible(True)
             self.entry_launch_arguments.set_text("PROTON_ENABLE_WAYLAND=0")
             self.entry_title.set_text(self.combobox_launcher.get_active_text())
-            self.entry_path.set_text(get_ea_app_path(self.entry_prefix.get_text()))
+            self.entry_path.set_text(
+                f"{self.entry_prefix.get_text()}/drive_c/Program Files/Electronic Arts/EA Desktop/EA Desktop/EALauncher.exe")
             shutil.copyfile(ea_icon, os.path.expanduser(self.icon_temp))
             pixbuf = GdkPixbuf.Pixbuf.new_from_file(self.icon_temp)
             scaled_pixbuf = pixbuf.scale_simple(50, 50, GdkPixbuf.InterpType.BILINEAR)

--- a/faugus/meson.build
+++ b/faugus/meson.build
@@ -2,6 +2,7 @@ py.install_sources(
   'components.py',
   'config_manager.py',
   'dark_theme.py',
+  'ea_fix.py',
   'language_config.py',
   'launcher.py',
   'path_manager.py',

--- a/faugus/runner.py
+++ b/faugus/runner.py
@@ -18,6 +18,7 @@ from gi.repository import Gtk, Gdk, GLib, GdkPixbuf
 from threading import Thread
 from faugus.config_manager import *
 from faugus.dark_theme import *
+from faugus.ea_fix import *
 
 IS_FLATPAK = 'FLATPAK_ID' in os.environ or os.path.exists('/.flatpak-info')
 from faugus.steam_setup import IS_STEAM_FLATPAK
@@ -809,6 +810,9 @@ def build_launch_command(game):
         lossless_hdr = 1
     else:
         lossless_hdr = 0
+
+    if gameid == "ea-app":
+        path = update_ea_path(prefix)
 
     command_parts = []
 


### PR DESCRIPTION
This should fix faugus/faugus-launcher#538. The version is detected by checking `C:\ProgramData\EA Desktop\machine.ini` which contains some meta data about the app including the current version. I have yet to check whether that mechanism survives an update of the app. I tried to fix all locations where the path is read/set/determined so that it is always up to date. If the path cannot be determined it will use the legacy path.

Feel free to adjust the error handling, style, etc.