### PR TITLE
simplify and make launcher script POSIX

### DIFF
--- a/faugus-launcher
+++ b/faugus-launcher
@@ -4,5 +4,5 @@ case "$1" in
 	--shortcut) exec /usr/bin/python3 -m faugus.shortcut "$2";;
 	--game)     exec /usr/bin/python3 -m faugus.runner --game "$2";;
 	--run)      exec /usr/bin/python3 -m faugus.runner "$2";;
-	*)          exec /usr/bin/python3 -m faugus.launcher "$1";;
+	*)          exec /usr/bin/python3 -m faugus.launcher "$@";;
 esac

--- a/faugus-launcher
+++ b/faugus-launcher
@@ -1,15 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-if [ "$1" = "--hide" ]; then
-    exec /usr/bin/python3 -m faugus.launcher --hide
-elif [ "$1" = "--shortcut" ]; then
-    exec /usr/bin/python3 -m faugus.shortcut "$2"
-elif [ "$1" = "--game" ]; then
-    exec /usr/bin/python3 -m faugus.runner --game "$2"
-elif [ "$1" = "--run" ]; then
-    exec /usr/bin/python3 -m faugus.runner "$2"
-elif [ -n "$1" ]; then
-    exec /usr/bin/python3 -m faugus.launcher "$1"
-else
-    exec /usr/bin/python3 -m faugus.launcher
-fi
+case "$1" in
+	--shortcut) exec /usr/bin/python3 -m faugus.shortcut "$2";;
+	--game)     exec /usr/bin/python3 -m faugus.runner --game "$2";;
+	--run)      exec /usr/bin/python3 -m faugus.runner "$2";;
+	*)          exec /usr/bin/python3 -m faugus.launcher "$1";;
+esac


### PR DESCRIPTION
* There is no need to use `bash` here.

* The original logic had a lot of duplicated if statements, for example it would check if `$1` was `--hide` to run `faugus.launcher --hide` and later on check if `$1` is set and passes that directly to `faugus.laucher` meaning there was no point in checking that specific flag.

* ~~There is no need to remove `$1` if empty from the arguments being passed as well.~~

EDIT: There was as the app changes behavior if you pass an empty string to it. You can still solve this by passing the positional array `$@` which does not pass an empty string when empty.

---

Is there a reason the script harcodes `python3` to `/usr/bin`?