### PR TITLE
Fix get_compatibilitytools path suffix attachment

### DIFF
--- a/faugus/path_manager.py
+++ b/faugus/path_manager.py
@@ -56,5 +56,6 @@ class PathManager:
 
     @staticmethod
     def get_compatibilitytools():
-        compatibilitytools_folder = Path(os.getenv('HOST_XDG_DATA_HOME', Path.home() / '.local/share') / 'Steam/compatibilitytools.d')
+        base_dir = Path(os.getenv('HOST_XDG_DATA_HOME', Path.home() / '.local' / 'share'))
+        compatibilitytools_folder = base_dir / 'Steam' / 'compatibilitytools.d'
         return str(compatibilitytools_folder)

--- a/faugus/path_manager.py
+++ b/faugus/path_manager.py
@@ -56,5 +56,5 @@ class PathManager:
 
     @staticmethod
     def get_compatibilitytools():
-        compatibilitytools_folder = Path(os.getenv('HOST_XDG_DATA_HOME', Path.home() / '.local/share/Steam/compatibilitytools.d'))
+        compatibilitytools_folder = Path(os.getenv('HOST_XDG_DATA_HOME', Path.home() / '.local/share') / 'Steam/compatibilitytools.d')
         return str(compatibilitytools_folder)


### PR DESCRIPTION
get_compatibilitytools() currently fails to properly resolve into ${HOST_XDG_DATA_HOME}/Steam/compatibilitytools.d, instead looking for Proton distribution directories directly under $HOST_XDG_DATA_HOME.

This PR attempts to fix that.

Please note that I did not test the change.