### PR TITLE
Fix GE-Proton downloading the wrong-architecture build

### DIFF
--- a/faugus/proton_downloader.py
+++ b/faugus/proton_downloader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import json
+import platform
 import tarfile
 import urllib.request
 import shutil
@@ -38,6 +39,12 @@ CONFIGS = {
     },
 }
 
+FOREIGN_ARCH_TOKENS = {
+    "x86_64": ("aarch64", "arm64"),
+    "aarch64": ("x86_64", "amd64"),
+    "arm64": ("x86_64", "amd64"),
+}
+
 def get_latest_tag_and_url(api, archive_ext):
     try:
         with urllib.request.urlopen(api, timeout=5) as r:
@@ -45,8 +52,14 @@ def get_latest_tag_and_url(api, archive_ext):
     except Exception:
         return None, None
 
+    foreign = FOREIGN_ARCH_TOKENS.get(platform.machine(), ())
     asset = next(
-        (a for a in data.get("assets", []) if a["name"].endswith(archive_ext)),
+        (
+            a
+            for a in data.get("assets", [])
+            if a["name"].endswith(archive_ext)
+            and not any(token in a["name"] for token in foreign)
+        ),
         None,
     )
 


### PR DESCRIPTION
proton_downloader selected the first release asset whose name ends with the configured extension. Since GE-Proton 11-1, the upstream release ships an aarch64 .tar.gz alongside the x86_64 one and lists the aarch64 asset first, so on x86_64 hosts faugus downloaded the aarch64 build. Its toolmanifest then made umu pull the aarch64 steamrt runtime, and games failed to launch with "Exec format error".

Make asset selection architecture-aware: skip assets carrying a foreign-architecture token (based on platform.machine()). This fixes GE-Proton on x86_64, is a no-op for the already arch-pinned CachyOS/DW configs, and also selects correctly on aarch64 hosts.