### PR TITLE
Fix GE-Proton downloading the wrong-architecture in Proton manager

### DIFF
--- a/faugus/proton_downloader.py
+++ b/faugus/proton_downloader.py
@@ -45,6 +45,21 @@ FOREIGN_ARCH_TOKENS = {
     "arm64": ("x86_64", "amd64"),
 }
 
+def select_asset(assets, archive_exts):
+    foreign_tokens = FOREIGN_ARCH_TOKENS.get(platform.machine(), ())
+    if isinstance(archive_exts, str):
+        archive_exts = [archive_exts]
+
+    return next(
+        (
+            a for a in assets
+            if any(a["name"].endswith(ext) for ext in archive_exts)
+            and not any(token in a["name"] for token in foreign_tokens)
+        ),
+        None,
+    )
+
+
 def get_latest_tag_and_url(api, archive_ext):
     try:
         with urllib.request.urlopen(api, timeout=5) as r:
@@ -52,17 +67,7 @@ def get_latest_tag_and_url(api, archive_ext):
     except Exception:
         return None, None
 
-    foreign = FOREIGN_ARCH_TOKENS.get(platform.machine(), ())
-    asset = next(
-        (
-            a
-            for a in data.get("assets", [])
-            if a["name"].endswith(archive_ext)
-            and not any(token in a["name"] for token in foreign)
-        ),
-        None,
-    )
-
+    asset = select_asset(data.get("assets", []), archive_ext)
     if not asset:
         return None, None
 

--- a/faugus/proton_manager.py
+++ b/faugus/proton_manager.py
@@ -7,6 +7,8 @@ import tarfile
 import shutil
 import threading
 
+from faugus.proton_downloader import select_asset
+
 gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gtk, GLib
@@ -256,12 +258,7 @@ class ProtonDownloader(Gtk.Dialog):
     def on_download_clicked(self, widget, release, variant):
         self.disable_all_buttons()
 
-        selected_asset = None
-        for asset in release["assets"]:
-            name = asset["name"]
-            if any(name.endswith(ext) for ext in variant["archive_ext"]):
-                selected_asset = asset
-                break
+        selected_asset = select_asset(release["assets"], variant["archive_ext"])
 
         if selected_asset:
             self.download_and_extract(


### PR DESCRIPTION
#762 fixed an issue when updating GE-Proton Latest, but Proton manager still uses old asset selection logic

Created a separate function `select_asset`. The only difference from the current `proton_downloader.py` logic is that it accepts an `archive_exts` array as an argument, which is required by Proton manager.