### PR TITLE
refactor (proton) stream download directly into tar extraction

### DIFF
--- a/faugus/proton_downloader.py
+++ b/faugus/proton_downloader.py
@@ -60,18 +60,28 @@ def select_asset(assets, archive_exts):
     )
 
 
+def get_tar_mode(name):
+    if name.endswith(('.tar.gz', '.tgz')):
+        return 'r|gz'
+    if name.endswith(('.tar.xz', '.txz')):
+        return 'r|xz'
+    if name.endswith(('.tar.bz2', '.tbz2')):
+        return 'r|bz2'
+    return 'r|'
+
+
 def get_latest_tag_and_url(api, archive_ext):
     try:
         with urllib.request.urlopen(api, timeout=5) as r:
             data = json.loads(r.read())
     except Exception:
-        return None, None
+        return None, None, None
 
     asset = select_asset(data.get("assets", []), archive_ext)
     if not asset:
-        return None, None
+        return None, None, None
 
-    return data["tag_name"], asset["browser_download_url"]
+    return data["tag_name"], asset["browser_download_url"], asset["name"]
 
 def get_installed_version(proton_dir):
     version_file = proton_dir / "version"
@@ -118,23 +128,20 @@ def rewrite_compatibilitytool_vdf(proton_dir, display_name):
 '''
     )
 
-def install_proton_latest(proton_dir, url, label):
-    archive = STEAM_COMPAT_DIR / url.split("/")[-1]
+def install_proton_latest(proton_dir, url, asset_name, label):
     tmp = STEAM_COMPAT_DIR / "__proton_tmp__"
 
     try:
-        print(f"Downloading {label}...", flush=True)
-        urllib.request.urlretrieve(url, archive)
+        print(f"Downloading & extracting {label}...", flush=True)
+        tmp.mkdir(parents=True, exist_ok=True)
+        response = urllib.request.urlopen(url, timeout=30)
+
+        with tarfile.open(fileobj=response, mode=get_tar_mode(asset_name)) as tar:
+            tar.extractall(tmp, filter="data")
     except Exception:
+        if tmp.exists():
+            shutil.rmtree(tmp)
         return
-
-    print(f"Extracting {label}...", flush=True)
-    tmp.mkdir(exist_ok=True)
-
-    with tarfile.open(archive) as tar:
-        tar.extractall(tmp, filter="data")
-
-    archive.unlink()
 
     extracted = next(tmp.iterdir())
 
@@ -150,7 +157,7 @@ def ensure_latest(kind):
     proton_dir = STEAM_COMPAT_DIR / cfg["dir"]
     proton_dir.parent.mkdir(parents=True, exist_ok=True)
 
-    latest_tag, url = get_latest_tag_and_url(cfg["api"], cfg["archive_ext"])
+    latest_tag, url, asset_name = get_latest_tag_and_url(cfg["api"], cfg["archive_ext"])
     if not url:
         return
 
@@ -160,7 +167,7 @@ def ensure_latest(kind):
         print(f"{cfg['label']} is up to date.", flush=True)
         return
 
-    install_proton_latest(proton_dir, url, cfg["label"])
+    install_proton_latest(proton_dir, url, asset_name, cfg["label"])
     rewrite_compatibilitytool_vdf(proton_dir, cfg["dir"])
 
 def main():
@@ -172,14 +179,9 @@ def main():
     group.add_argument("--dw", action="store_true")
     args = parser.parse_args()
 
-    if args.ge:
-        ensure_latest("ge")
-    if args.em:
-        ensure_latest("em")
-    if args.cachyos:
-        ensure_latest("cachyos")
-    if args.dw:
-        ensure_latest("dw")
+    for key in vars(args):
+        if getattr(args, key):
+            ensure_latest(key)
 
 if __name__ == "__main__":
     main()

--- a/faugus/proton_manager.py
+++ b/faugus/proton_manager.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 
-import os
 import requests
 import gi
 import tarfile
 import shutil
 import threading
 
-from faugus.proton_downloader import select_asset
+from faugus.proton_downloader import select_asset, get_tar_mode
 
 gi.require_version("Gtk", "3.0")
 
@@ -61,6 +60,24 @@ VARIANTS = {
         "tag_to_display": lambda tag: f"DW-Proton-{tag.removeprefix('dwproton-')}",
     },
 }
+
+
+class _StreamProgress:
+    def __init__(self, raw, total_size, progress_callback):
+        self.raw = raw
+        self.total_size = total_size
+        self.progress_callback = progress_callback
+        self.bytes_read = 0
+
+    def read(self, size=-1):
+        chunk = self.raw.read(size)
+        self.bytes_read += len(chunk)
+        if self.total_size > 0:
+            self.progress_callback(self.bytes_read / self.total_size)
+        return chunk
+
+    def close(self):
+        self.raw.close()
 
 
 class ProtonDownloader(Gtk.Dialog):
@@ -286,46 +303,23 @@ class ProtonDownloader(Gtk.Dialog):
         def worker():
             try:
                 compatibility_dir.mkdir(parents=True, exist_ok=True)
-                tar_file_path = os.path.join(compatibility_dir, filename)
 
                 response = requests.get(url, stream=True, timeout=30)
                 response.raise_for_status()
                 total_size = int(response.headers.get("content-length", 0))
-                downloaded_size = 0
-                last_pct = -1
 
-                with open(tar_file_path, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=1024*64):
-                        if not chunk: break
-                        f.write(chunk)
-                        downloaded_size += len(chunk)
-                        if total_size > 0:
-                            pct = int(downloaded_size * 1200 / total_size)
-                            if pct != last_pct:
-                                last_pct = pct
-                                GLib.idle_add(self.progress_bar.set_fraction, downloaded_size / total_size)
-                                GLib.idle_add(self.progress_bar.set_text, f"{pct / 3:.1f}%")
+                last_pct = [-1]
+                def _progress(frac):
+                    pct = int(frac * 1000)
+                    if pct != last_pct[0]:
+                        last_pct[0] = pct
+                        GLib.idle_add(self.progress_bar.set_fraction, frac)
+                        GLib.idle_add(self.progress_bar.set_text, f"{pct / 10:.1f}%")
 
-                GLib.idle_add(self.progress_label.set_text, _("Extracting %s...") % tag_name)
-                GLib.idle_add(self.progress_bar.set_fraction, 0)
+                stream = _StreamProgress(response.raw, total_size, _progress)
 
-                mode = 'r:xz' if tar_file_path.endswith('.tar.xz') else 'r:gz'
-
-                with tarfile.open(tar_file_path, mode) as tar:
-                    members = tar.getmembers()
-                    total_members = len(members)
-                    last_pct = -1
-
-                    for i, member in enumerate(members):
-                        tar.extract(member, path=compatibility_dir, filter="fully_trusted")
-                        pct = int((i + 1) * 1200 / total_members)
-                        if pct != last_pct:
-                            last_pct = pct
-                            GLib.idle_add(self.progress_bar.set_fraction, (i + 1) / total_members)
-                            GLib.idle_add(self.progress_bar.set_text, f"{pct / 3:.1f}%")
-
-                if os.path.exists(tar_file_path):
-                    os.remove(tar_file_path)
+                with tarfile.open(fileobj=stream, mode=get_tar_mode(filename)) as tar:
+                    tar.extractall(path=compatibility_dir, filter="fully_trusted")
 
                 GLib.idle_add(self.update_button, button, _("Remove"))
                 GLib.idle_add(self.progress_bar.set_visible, False)


### PR DESCRIPTION
This refactoring eliminates intermediate archive files by streaming downloads directly into tar extraction for both proton_downloader and proton_manager. Updating/downloading Proton is much faster.

I havent noticed any regressions but it would be good if you could test it thoroughly.