### PR TITLE
Add per-game pre-launch and post-exit hooks

### DIFF
--- a/faugus/launcher.py
+++ b/faugus/launcher.py
@@ -2444,6 +2444,8 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
             edit_game_dialog.entry_path.set_text(game.path)
             edit_game_dialog.entry_prefix.set_text(game.prefix)
             edit_game_dialog.launch_arguments = game.launch_arguments
+            edit_game_dialog.pre_launch_command = game.pre_launch_command
+            edit_game_dialog.post_exit_command = game.post_exit_command
             edit_game_dialog.entry_game_arguments.set_text(game.game_arguments)
             edit_game_dialog.set_title(_("Edit %s") % game.title)
             edit_game_dialog.entry_protonfix.set_text(game.protonfix)
@@ -2734,6 +2736,8 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
 
             path = add_game_dialog.entry_path.get_text()
             launch_arguments = add_game_dialog.launch_arguments
+            pre_launch_command = add_game_dialog.pre_launch_command
+            post_exit_command = add_game_dialog.post_exit_command
             game_arguments = add_game_dialog.entry_game_arguments.get_text()
             protonfix = add_game_dialog.entry_protonfix.get_text()
             runner = add_game_dialog.combobox_runner.get_active_text()
@@ -2825,6 +2829,8 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
                 lossless_performance,
                 lossless_hdr,
                 lossless_present,
+                pre_launch_command,
+                post_exit_command,
                 playtime,
                 hidden,
                 prevent_sleep,
@@ -3096,6 +3102,8 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
             game.path = edit_game_dialog.entry_path.get_text()
             game.prefix = os.path.normpath(edit_game_dialog.entry_prefix.get_text())
             game.launch_arguments = edit_game_dialog.launch_arguments
+            game.pre_launch_command = edit_game_dialog.pre_launch_command
+            game.post_exit_command = edit_game_dialog.post_exit_command
             game.game_arguments = edit_game_dialog.entry_game_arguments.get_text()
             game.mangohud = edit_game_dialog.checkbox_mangohud.get_active()
             game.gamemode = edit_game_dialog.checkbox_gamemode.get_active()
@@ -4569,6 +4577,8 @@ class Game:
         lossless_performance,
         lossless_hdr,
         lossless_present,
+        pre_launch_command,
+        post_exit_command,
         playtime,
         hidden,
         prevent_sleep,
@@ -4598,6 +4608,8 @@ class Game:
         self.lossless_performance = lossless_performance
         self.lossless_hdr = lossless_hdr
         self.lossless_present = lossless_present
+        self.pre_launch_command = pre_launch_command
+        self.post_exit_command = post_exit_command
         self.playtime = playtime
         self.hidden = hidden
         self.prevent_sleep = prevent_sleep
@@ -4962,6 +4974,10 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.button_launch_arguments.connect("clicked", self.on_button_launch_arguments_clicked)
         self.button_launch_arguments.set_tooltip_text(_("e.g.: PROTON_USE_WINED3D=1 gamescope -W 2560 -H 1440"))
 
+        self.button_game_hooks = Gtk.Button(label=_("Game Hooks"))
+        self.button_game_hooks.connect("clicked", self.on_button_game_hooks_clicked)
+        self.button_game_hooks.set_tooltip_text(_("Run commands before launch and after the game exits"))
+
         self.button_addapp = Gtk.Button(label=_("Additional Application"))
         self.button_addapp.connect("clicked", self.on_button_addapp_clicked)
         self.button_addapp.set_tooltip_text(
@@ -5160,6 +5176,9 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.grid_launch_arguments.attach(self.button_launch_arguments, 0, 0, 1, 1)
         self.button_launch_arguments.set_hexpand(True)
 
+        self.grid_launch_arguments.attach(self.button_game_hooks, 0, 1, 1, 1)
+        self.button_game_hooks.set_hexpand(True)
+
         self.grid_addapp.attach(self.button_addapp, 0, 0, 1, 1)
         self.button_addapp.set_hexpand(True)
 
@@ -5274,6 +5293,11 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
 
     def on_button_launch_arguments_clicked(self, widget):
         self.launch_arguments = show_launch_arguments_dialog(self, self.launch_arguments)
+
+    def on_button_game_hooks_clicked(self, widget):
+        (self.pre_launch_command,
+         self.post_exit_command) = show_game_hooks_dialog(
+            self, self.pre_launch_command, self.post_exit_command)
 
     def on_button_addapp_clicked(self, widget):
         (self.addapp_enabled, self.addapp,

--- a/faugus/runner.py
+++ b/faugus/runner.py
@@ -41,6 +41,7 @@ class FaugusRun(HiDpiMixin):
         self.log_window = None
         self.text_view = None
         self.proton_latest = None
+        self._post_hook_ran = False
 
         self.load_config()
         signal.signal(signal.SIGUSR1, self.on_process_exit)
@@ -206,6 +207,23 @@ class FaugusRun(HiDpiMixin):
 
     def execute_final_command(self):
 
+        def run_game_hook(env_name, phase):
+            command = os.environ.get(env_name, "").strip()
+            if not command:
+                return True
+
+            hook_env = os.environ.copy()
+            hook_env["FAUGUS_HOOK_PHASE"] = phase
+            hook_env["FAUGUS_GAME_ID"] = hook_env.get("FAUGUSID", "")
+            print(f"\n=== {phase.upper()} HOOK ===\n{command}\n")
+            result = subprocess.run(command, shell=True, env=hook_env)
+            if result.returncode:
+                print(f"{phase.capitalize()} hook failed with exit code {result.returncode}.")
+                return False
+            return True
+
+        self.run_game_hook = run_game_hook
+
         def start_and_watch(cmd, is_game=False):
             log_file = None
             if self.enable_logging:
@@ -283,6 +301,10 @@ class FaugusRun(HiDpiMixin):
             start_and_watch(cmd)
 
         game_cmd = popen_prefix + shlex.split(self.message)
+        if not self.run_game_hook("FAUGUS_PRE_LAUNCH_COMMAND", "pre-launch"):
+            GLib.idle_add(self.close_splash_window)
+            GLib.idle_add(Gtk.main_quit)
+            return
         self.start_time = time.time()
         start_and_watch(game_cmd, is_game=True)
 
@@ -699,7 +721,7 @@ class FaugusRun(HiDpiMixin):
                 Gtk.main_quit()
                 sys.exit()
 
-    def on_process_exit(self, pid, condition):
+    def on_process_exit(self, pid=None, condition=None):
         import psutil
         def kill_child_proc():
 
@@ -750,6 +772,10 @@ class FaugusRun(HiDpiMixin):
         GLib.idle_add(Gtk.main_quit)
         kill_child_proc()
 
+        if not self._post_hook_ran:
+            self._post_hook_ran = True
+            self.run_game_hook("FAUGUS_POST_EXIT_COMMAND", "post-exit")
+
         return False
 
 def build_launch_command(game):
@@ -773,6 +799,8 @@ def build_launch_command(game):
     lossless_hdr = game.get("lossless_hdr", "")
     lossless_present = game.get("lossless_present", "")
     icon = game.get("icon", "")
+    pre_launch_command = game.get("pre_launch_command", "")
+    post_exit_command = game.get("post_exit_command", "")
 
     if gameid == "ea-app":
         path = update_ea_path(prefix)
@@ -784,6 +812,10 @@ def build_launch_command(game):
     if gameid:
         command_parts.append(f"LOG_DIR='{gameid}'")
         command_parts.append(f"FAUGUSID={gameid}")
+    if pre_launch_command:
+        command_parts.append(f"FAUGUS_PRE_LAUNCH_COMMAND={shlex.quote(pre_launch_command)}")
+    if post_exit_command:
+        command_parts.append(f"FAUGUS_POST_EXIT_COMMAND={shlex.quote(post_exit_command)}")
     if disable_hidraw:
         command_parts.append("PROTON_DISABLE_HIDRAW=1")
     if prevent_sleep:

--- a/faugus/utils.py
+++ b/faugus/utils.py
@@ -485,6 +485,7 @@ GAME_FIELDS = [
     "banner",
     "lossless_enabled", "lossless_multiplier", "lossless_flow",
     "lossless_performance", "lossless_hdr", "lossless_present",
+    "pre_launch_command", "post_exit_command",
     "playtime", "hidden", "prevent_sleep", "category", "icon",
 ]
 
@@ -513,12 +514,101 @@ def init_addon_defaults(obj):
     obj.addapp_delay = ""
     obj.addapp_first = False
     obj.launch_arguments = ""
+    obj.pre_launch_command = ""
+    obj.post_exit_command = ""
     obj.lossless_enabled = False
     obj.lossless_multiplier = 1
     obj.lossless_flow = 100
     obj.lossless_performance = False
     obj.lossless_hdr = False
     obj.lossless_present = False
+
+def show_game_hooks_dialog(parent, pre_launch_command, post_exit_command):
+    dialog = Gtk.Dialog(title=_("Game Hooks"), parent=parent, flags=0)
+    dialog.set_resizable(True)
+    dialog.set_modal(True)
+    dialog.set_default_size(700, 500)
+
+    hooks_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+    hooks_box.set_margin_start(10)
+    hooks_box.set_margin_end(10)
+    hooks_box.set_margin_top(10)
+    hooks_box.set_margin_bottom(10)
+
+    pre_label = Gtk.Label(label=_("Pre-launch command"))
+    pre_label.set_halign(Gtk.Align.START)
+    pre_hint = Gtk.Label(label=_("Runs before the game starts; a non-zero exit cancels launch."))
+    pre_hint.set_halign(Gtk.Align.START)
+    pre_hint.get_style_context().add_class("dim-label")
+    pre_buffer = Gtk.TextBuffer()
+    pre_buffer.set_text(pre_launch_command)
+    pre_editor = Gtk.TextView(buffer=pre_buffer)
+    pre_editor.set_monospace(True)
+    pre_editor.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+    pre_editor.set_top_margin(6)
+    pre_editor.set_bottom_margin(6)
+    pre_scroll = Gtk.ScrolledWindow()
+    pre_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+    pre_scroll.set_min_content_height(150)
+    pre_scroll.set_vexpand(True)
+    pre_scroll.add(pre_editor)
+
+    post_label = Gtk.Label(label=_("Post-exit command"))
+    post_label.set_halign(Gtk.Align.START)
+    post_hint = Gtk.Label(label=_("Runs after the tracked game process exits."))
+    post_hint.set_halign(Gtk.Align.START)
+    post_hint.get_style_context().add_class("dim-label")
+    post_buffer = Gtk.TextBuffer()
+    post_buffer.set_text(post_exit_command)
+    post_editor = Gtk.TextView(buffer=post_buffer)
+    post_editor.set_monospace(True)
+    post_editor.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+    post_editor.set_top_margin(6)
+    post_editor.set_bottom_margin(6)
+    post_scroll = Gtk.ScrolledWindow()
+    post_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+    post_scroll.set_min_content_height(150)
+    post_scroll.set_vexpand(True)
+    post_scroll.add(post_editor)
+
+    hooks_box.pack_start(pre_label, False, False, 0)
+    hooks_box.pack_start(pre_hint, False, False, 0)
+    hooks_box.pack_start(pre_scroll, True, True, 0)
+    hooks_box.pack_start(post_label, False, False, 0)
+    hooks_box.pack_start(post_hint, False, False, 0)
+    hooks_box.pack_start(post_scroll, True, True, 0)
+
+    content_area = dialog.get_content_area()
+    content_area.pack_start(hooks_box, True, True, 0)
+
+    button_cancel = Gtk.Button(label=_("Cancel"))
+    button_cancel.set_size_request(150, -1)
+    button_cancel.set_hexpand(True)
+    button_cancel.connect("clicked", lambda b: dialog.response(Gtk.ResponseType.CANCEL))
+    button_ok = Gtk.Button(label=_("Ok"))
+    button_ok.set_size_request(150, -1)
+    button_ok.set_hexpand(True)
+    button_ok.connect("clicked", lambda b: dialog.response(Gtk.ResponseType.OK))
+
+    bottom_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+    bottom_box.set_margin_start(10)
+    bottom_box.set_margin_end(10)
+    bottom_box.set_margin_bottom(10)
+    bottom_box.pack_start(button_cancel, True, True, 0)
+    bottom_box.pack_start(button_ok, True, True, 0)
+    content_area.pack_start(bottom_box, False, False, 0)
+
+    dialog.show_all()
+    response = dialog.run()
+    if response == Gtk.ResponseType.OK:
+        result = (
+            pre_buffer.get_text(pre_buffer.get_start_iter(), pre_buffer.get_end_iter(), False).strip(),
+            post_buffer.get_text(post_buffer.get_start_iter(), post_buffer.get_end_iter(), False).strip(),
+        )
+    else:
+        result = (pre_launch_command, post_exit_command)
+    dialog.destroy()
+    return result
 
 def show_launch_arguments_dialog(parent, current_launch_arguments):
     dialog = Gtk.Dialog(title=_("Launch Arguments"), parent=parent, flags=0)


### PR DESCRIPTION
## Summary
- add configurable per-game pre-launch and post-exit shell hooks
- cancel launch when a pre-launch hook fails
- persist hook commands with game configuration
## Validation
- python syntax compilation