### PR TITLE
Add GTK background CSS class to launcher background

### DIFF
--- a/faugus/launcher.py
+++ b/faugus/launcher.py
@@ -386,6 +386,7 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
         overlay = Gtk.Overlay()
 
         base_box = Gtk.Box()
+        base_box.add_css_class("background")
         base_box.set_hexpand(True)
         base_box.set_vexpand(True)
         if base_mode == "accent":


### PR DESCRIPTION
Fixes launcher transparency on some GTK themes (Orchis-Dark) by adding the standard GTK `background` CSS class to the base `Gtk.Box`. Tested with Orchis-Dark and Adwaita. Below are before/after screenshots.
## Before

<img width="456" height="626" alt="faugus_broken" src="https://github.com/user-attachments/assets/c63cb102-5249-4e56-8a30-fcb85173711e" />

## After
<img width="437" height="621" alt="faugus_fixed" src="https://github.com/user-attachments/assets/01a83fa6-361a-4a78-b72b-fb79017c4a68" />
