### PR TITLE
Use system UMU if available

### DIFF
--- a/faugus/components.py
+++ b/faugus/components.py
@@ -5,7 +5,7 @@ import requests
 import tarfile
 import shutil
 
-from faugus.path_manager import FAUGUS_LAUNCHER_SHARE_DIR, DOWNLOAD_DIR, UMU_RUN
+from faugus.path_manager import FAUGUS_LAUNCHER_SHARE_DIR, DOWNLOAD_DIR, UMU_RUN, PathManager
 
 UMU_URL_TEMPLATE = "https://github.com/Faugus/umu-launcher/releases/download/{}/umu-run"
 UMU_VERSION_API = "https://api.github.com/repos/Faugus/umu-launcher/releases"
@@ -53,6 +53,9 @@ def download_umu_run(version):
 
 
 def update_umu():
+    if PathManager.find_binary("umu-run") != "":
+        return
+
     latest = get_latest_umu_version()
     current = get_installed_umu_version()
 

--- a/faugus/path_manager.py
+++ b/faugus/path_manager.py
@@ -189,7 +189,7 @@ RUNNING_GAMES = PathManager.user_state('faugus-launcher/running-games.json')
 FILECHOOSER_FOLDERS_FILE = PathManager.user_state('faugus-launcher/filechooser_folders.json')
 ICONS_DIR = PathManager.user_data('faugus-launcher/icons')
 PROTON_CACHYOS = PathManager.system_data('steam/compatibilitytools.d/proton-cachyos-slr/')
-UMU_RUN = PathManager.user_data('faugus-launcher/umu-run')
+UMU_RUN = PathManager.find_binary('umu-run') or PathManager.user_data('faugus-launcher/umu-run')
 COMPATIBILITY_DIR = Path(PathManager.get_compatibilitytools())
 COMPATIBILITY_DIRS = [Path(p) for p in PathManager.get_compatibilitytools_dirs()]
 


### PR DESCRIPTION
We should use UMU from PATH if it's available. And if that's the case we shouldn't try to update UMU upon start (for consistency).