### PR TITLE
Adding support for "Proton-GE (System)"

### DIFF
--- a/faugus/path_manager.py
+++ b/faugus/path_manager.py
@@ -189,6 +189,7 @@ RUNNING_GAMES = PathManager.user_state('faugus-launcher/running-games.json')
 FILECHOOSER_FOLDERS_FILE = PathManager.user_state('faugus-launcher/filechooser_folders.json')
 ICONS_DIR = PathManager.user_data('faugus-launcher/icons')
 PROTON_CACHYOS = PathManager.system_data('steam/compatibilitytools.d/proton-cachyos-slr/')
+PROTON_GE = PathManager.system_data('steam/compatibilitytools.d/proton-ge-custom/')
 UMU_RUN = PathManager.user_data('faugus-launcher/umu-run')
 COMPATIBILITY_DIR = Path(PathManager.get_compatibilitytools())
 COMPATIBILITY_DIRS = [Path(p) for p in PathManager.get_compatibilitytools_dirs()]

--- a/faugus/runner.py
+++ b/faugus/runner.py
@@ -204,6 +204,9 @@ class FaugusRun(HiDpiMixin):
             if protonpath == "Proton-CachyOS (System)" and not os.path.exists(PROTON_CACHYOS):
                 self.close_splash_window()
                 self.show_error_dialog(protonpath)
+            elif protonpath == "Proton-GE (System)" and not os.path.exists(PROTON_GE):
+                self.close_splash_window()
+                self.show_error_dialog(protonpath)
             elif protonpath == "Linux-Native":
                 pass
             elif protonpath == "Steam":
@@ -812,6 +815,9 @@ def build_launch_command(game):
         elif runner == "Proton-CachyOS (System)":
             command_parts.append(f"WINEPREFIX={shlex.quote(prefix)}")
             command_parts.append(f"PROTONPATH={PROTON_CACHYOS}")
+        elif runner == "Proton-GE (System)":
+            command_parts.append(f"WINEPREFIX={shlex.quote(prefix)}")
+            command_parts.append(f"PROTONPATH={PROTON_GE}")
         else:
             command_parts.append(f"WINEPREFIX={shlex.quote(prefix)}")
             command_parts.append(f"PROTONPATH='{runner}'")

--- a/faugus/utils.py
+++ b/faugus/utils.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 import gi
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
-from faugus.path_manager import PathManager, GAMES_JSON, PRESETS_FILE, COMPATIBILITY_DIR, COMPATIBILITY_DIRS, find_compatibilitytool, PROTON_CACHYOS, MANGOHUD_DIR, GAMEMODERUN, ICONS_DIR, COVERS_DIR, FAUGUS_NOTIFICATION, FILECHOOSER_FOLDERS_FILE, IS_FLATPAK, CONFIG_FILE_DIR
+from faugus.path_manager import PathManager, GAMES_JSON, PRESETS_FILE, COMPATIBILITY_DIR, COMPATIBILITY_DIRS, find_compatibilitytool, PROTON_CACHYOS, PROTON_GE, MANGOHUD_DIR, GAMEMODERUN, ICONS_DIR, COVERS_DIR, FAUGUS_NOTIFICATION, FILECHOOSER_FOLDERS_FILE, IS_FLATPAK, CONFIG_FILE_DIR
 from gi.repository import Gtk, Gdk, Gio, GLib, GdkPixbuf, Pango, GObject, Adw
 
 os.environ.setdefault("VK_LOADER_LAYERS_DISABLE", "VK_LAYER_LSFGVK_frame_generation")
@@ -1046,6 +1046,10 @@ def update_games_json():
         if game.get("runner") == "Proton-CachyOS":
             game["runner"] = "Proton-CachyOS (System)"
             changed = True
+        
+        if game.get("runner") == "Proton-GE":
+            game["runner"] = "Proton-GE (System)"
+            changed = True
 
         if "favorite" in game:
             if game["favorite"] == True:
@@ -1100,6 +1104,9 @@ def populate_combobox_with_runners(combobox):
 
     if os.path.exists(PROTON_CACHYOS):
         combobox.append("Proton-CachyOS (System)", "Proton-CachyOS ({})".format(_("System")))
+    
+    if os.path.exists(PROTON_GE):
+        combobox.append("Proton-GE (System)", "Proton-GE ({})".format(_("System")))
 
     try:
         versions = set()


### PR DESCRIPTION
_("Proton-GE (System)" referring to the one provided by [proton-ge-custom-bin](https://aur.archlinux.org/packages/proton-ge-custom-bin))_

If Faugus supports system-wide installation of Proton-CachyOS, there should be no reason it wouldn’t also support system-wide installation of Proton-GE.