### PR TITLE
Add support for Steam Linux Runtime selection

### DIFF
--- a/faugus/launcher.py
+++ b/faugus/launcher.py
@@ -4155,8 +4155,9 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
             if game_runner == "Linux-Native":
                 edit_game_dialog.combobox_launcher.set_active_id_silent("linux")
                 edit_game_dialog.on_combobox_changed(edit_game_dialog.combobox_launcher, skip_cleanup=True)
-                edit_game_dialog.checkbox_disable_umu.set_active(game.disable_umu == True)
-                edit_game_dialog.combobox_runtime.set_active_id_silent(game.runtime)
+                edit_game_dialog.combobox_runtime.set_active_id_silent(
+                    game.runtime or ("disable-runtime" if game.disable_umu else "auto")
+                )
             if game_runner == "Steam":
                 edit_game_dialog.combobox_launcher.set_active_id_silent("steam")
                 edit_game_dialog.on_combobox_changed(edit_game_dialog.combobox_launcher, skip_cleanup=True)
@@ -4516,7 +4517,7 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
                 no_sleep = True if add_game_dialog.checkbox_no_sleep.get_active() else ""
 
             disable_umu = True if (
-                launcher_id == "linux" and add_game_dialog.checkbox_disable_umu.get_active()
+                launcher_id == "linux" and add_game_dialog.combobox_runtime.get_active_id() == "disable-runtime"
             ) else ""
 
             game = Game(
@@ -4915,8 +4916,8 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
 
             if edit_game_dialog.combobox_launcher.get_active_id() == "linux":
                 game.runner = "Linux-Native"
-                game.disable_umu = True if edit_game_dialog.checkbox_disable_umu.get_active() else ""
                 game.runtime = edit_game_dialog.combobox_runtime.get_active_id()
+                game.disable_umu = True if game.runtime == "disable-runtime" else ""
             else:
                 game.disable_umu = ""
             if edit_game_dialog.combobox_launcher.get_active_id() == "steam":
@@ -6921,10 +6922,6 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.button_lossless.connect("clicked", self.on_button_lossless_clicked)
 
         create_mangohud_gamemode_checkboxes(self)
-        self.checkbox_disable_umu = Gtk.CheckButton(label=_("Disable UMU"))
-        self.checkbox_disable_umu.set_tooltip_text(
-            _("Runs the game without the Steam Runtime"))
-        self.checkbox_disable_umu.set_visible(False)
         self.checkbox_sdl = Gtk.CheckButton(label="SDL")
         self.checkbox_sdl.set_tooltip_text(_("May fix gamepad issues with some games"))
         self.checkbox_no_sleep = Gtk.CheckButton(label=_("No Sleep"))
@@ -7225,8 +7222,6 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.grid_path.attach(self.entry_path, 0, 1, 3, 1)
         self.entry_path.set_hexpand(True)
         self.grid_path.attach(self.button_search, 3, 1, 1, 1)
-        self.grid_path.attach(self.checkbox_disable_umu, 0, 2, 4, 1)
-        self.checkbox_disable_umu.set_hexpand(True)
 
         self.grid_runtime.attach(self.label_runtime, 0, 0, 1, 1)
         self.grid_runtime.attach(self.combobox_runtime, 0, 1, 1, 1)
@@ -7331,7 +7326,7 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
 
         self.populate_combobox_with_runners()
         self.populate_combobox_with_runtimes()
-        self.combobox_runtime.set_active_id("umu-sniper")
+        self.combobox_runtime.set_active_id("auto")
 
         if not self.combobox_runner.set_active_id(self.default_runner):
             self.combobox_runner.set_active(0)
@@ -7970,7 +7965,6 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.checkbox_gamemode.set_active(self.default_gamemode)
         self.checkbox_sdl.set_active(self.default_sdl_enabled)
         self.checkbox_no_sleep.set_active(self.default_no_sleep)
-        self.checkbox_disable_umu.set_active(False)
         self.button_shortcut_icon.set_child(self.set_image_shortcut_icon())
         if os.path.isfile(self.cover_path_temp):
             os.remove(self.cover_path_temp)
@@ -8010,7 +8004,6 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.grid_protonfix.set_visible(False)
         self.grid_addapp.set_visible(False)
         self.checkbox_sdl.set_visible(False)
-        self.checkbox_disable_umu.set_visible(False)
         self.checkbox_no_sleep.set_visible(True)
         self.checkbox_shortcut_steam.set_visible(True)
         self.combobox_steam_shortcut_user.set_visible(True)
@@ -8039,7 +8032,6 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
             self.grid_runtime.set_visible(True)
             self.label_runtime.set_visible(True)
             self.button_shortcut_icon.set_visible(True)
-            self.checkbox_disable_umu.set_visible(True)
             self.combobox_runtime.set_visible(True)
 
         elif active_id == "steam":
@@ -8122,11 +8114,12 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.combobox_launcher.append("wargaming", "Wargaming Game Center")
 
     def populate_combobox_with_runtimes(self):
-        self.combobox_runtime.append("umu-host", _("Disable runtime"))
-        self.combobox_runtime.append("umu-scout", _("Scout"))
-        self.combobox_runtime.append("umu-soldier", _("Soldier"))
-        self.combobox_runtime.append("umu-sniper", _("Sniper"))
+        self.combobox_runtime.append("auto", "{} ({})".format(_("Auto"), _("Default")))
+        self.combobox_runtime.append("disable-runtime", _("Disable Runtime"))
         self.combobox_runtime.append("umu-steamrt4", _("SteamRT4"))
+        self.combobox_runtime.append("umu-sniper", _("Sniper"))
+        self.combobox_runtime.append("umu-soldier", _("Soldier"))
+        self.combobox_runtime.append("umu-scout", _("Scout"))
 
     def populate_combobox_with_runners(self):
         populate_combobox_with_runners(self.combobox_runner)

--- a/faugus/launcher.py
+++ b/faugus/launcher.py
@@ -4156,6 +4156,7 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
                 edit_game_dialog.combobox_launcher.set_active_id_silent("linux")
                 edit_game_dialog.on_combobox_changed(edit_game_dialog.combobox_launcher, skip_cleanup=True)
                 edit_game_dialog.checkbox_disable_umu.set_active(game.disable_umu == True)
+                edit_game_dialog.combobox_runtime.set_active_id_silent(game.runtime)
             if game_runner == "Steam":
                 edit_game_dialog.combobox_launcher.set_active_id_silent("steam")
                 edit_game_dialog.on_combobox_changed(edit_game_dialog.combobox_launcher, skip_cleanup=True)
@@ -4552,6 +4553,7 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
                 post_launch=add_game_dialog.post_launch,
                 steam_user=add_game_dialog.combobox_steam_user.get_active_id() if launcher_id == "steam" else "",
                 disable_umu=disable_umu,
+                runtime=add_game_dialog.combobox_runtime.get_active_id()
             )
 
             desktop_shortcut_state = add_game_dialog.checkbox_shortcut_desktop.get_active()
@@ -4914,6 +4916,7 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
             if edit_game_dialog.combobox_launcher.get_active_id() == "linux":
                 game.runner = "Linux-Native"
                 game.disable_umu = True if edit_game_dialog.checkbox_disable_umu.get_active() else ""
+                game.runtime = edit_game_dialog.combobox_runtime.get_active_id()
             else:
                 game.disable_umu = ""
             if edit_game_dialog.combobox_launcher.get_active_id() == "steam":
@@ -6466,6 +6469,7 @@ class Game:
         post_launch="",
         steam_user="",
         disable_umu="",
+        runtime="",
     ):
         self.gameid = gameid
         self.title = title
@@ -6495,11 +6499,13 @@ class Game:
         self.no_sleep = no_sleep
         self.category = category
         self.icon = icon
+        self.runtime = runtime
         self.steamgriddb_id = steamgriddb_id
         self.pre_launch = pre_launch
         self.post_launch = post_launch
         self.steam_user = steam_user
         self.disable_umu = disable_umu
+        self.runtime = runtime
 
 
 class DuplicateDialog(Gtk.Dialog):
@@ -6710,6 +6716,8 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
 
         self.grid_path = build_grid(margin_bottom=False)
 
+        self.grid_runtime = build_grid(margin_bottom=False)
+
         self.grid_prefix = build_grid(margin_bottom=False)
 
         self.grid_runner = build_grid(margin_bottom=False)
@@ -6863,6 +6871,12 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.button_search.set_child(Gtk.Image.new_from_icon_name("system-search-symbolic"))
         self.button_search.connect("clicked", self.on_button_search_clicked)
         self.button_search.set_size_request(50, -1)
+
+        self.label_runtime = Gtk.Label(label=_("Runtime"))
+        self.label_runtime.set_halign(Gtk.Align.START)
+        self.label_runtime.set_visible(False)
+        self.combobox_runtime = IdComboBox()
+        self.combobox_runtime.set_visible(False)
 
         self.label_prefix = Gtk.Label(label=_("Prefix"))
         self.label_prefix.set_halign(Gtk.Align.START)
@@ -7214,6 +7228,10 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.grid_path.attach(self.checkbox_disable_umu, 0, 2, 4, 1)
         self.checkbox_disable_umu.set_hexpand(True)
 
+        self.grid_runtime.attach(self.label_runtime, 0, 0, 1, 1)
+        self.grid_runtime.attach(self.combobox_runtime, 0, 1, 1, 1)
+        self.combobox_runtime.set_hexpand(True)
+
         self.grid_prefix.attach(self.label_prefix, 0, 0, 1, 1)
         self.grid_prefix.attach(self.entry_prefix, 0, 1, 3, 1)
         self.entry_prefix.set_hexpand(True)
@@ -7240,6 +7258,7 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         page1.append(self.grid_steam_title)
         page1.append(self.grid_title)
         page1.append(self.grid_path)
+        page1.append(self.grid_runtime)
         page1.append(self.grid_prefix)
         page1.append(self.grid_runner)
         page1.append(self.label_shortcut)
@@ -7311,6 +7330,8 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.combobox_launcher.connect("changed", self.on_combobox_changed)
 
         self.populate_combobox_with_runners()
+        self.populate_combobox_with_runtimes()
+        self.combobox_runtime.set_active_id("umu-sniper")
 
         if not self.combobox_runner.set_active_id(self.default_runner):
             self.combobox_runner.set_active(0)
@@ -7981,6 +8002,7 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.grid_steam_user.set_visible(False)
         self.grid_path.set_visible(False)
         self.grid_runner.set_visible(False)
+        self.grid_runtime.set_visible(False)
         self.grid_prefix.set_visible(False)
         self.button_winetricks.set_visible(False)
         self.button_winecfg.set_visible(False)
@@ -7992,6 +8014,7 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.checkbox_no_sleep.set_visible(True)
         self.checkbox_shortcut_steam.set_visible(True)
         self.combobox_steam_shortcut_user.set_visible(True)
+        self.combobox_runtime.set_visible(False)
         self.grid_page2.set_visible(True)
         self.tab_button_widgets[self.tab_names.index("page2")].set_visible(True)
         self.tab_switcher.set_visible(True)
@@ -8013,8 +8036,11 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         elif active_id == "linux":
             self.grid_title.set_visible(True)
             self.grid_path.set_visible(True)
+            self.grid_runtime.set_visible(True)
+            self.label_runtime.set_visible(True)
             self.button_shortcut_icon.set_visible(True)
             self.checkbox_disable_umu.set_visible(True)
+            self.combobox_runtime.set_visible(True)
 
         elif active_id == "steam":
             self.grid_steam_title.set_visible(True)
@@ -8094,6 +8120,13 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.combobox_launcher.append("rockstar", "Rockstar Launcher")
         self.combobox_launcher.append("ubisoft", "Ubisoft Connect")
         self.combobox_launcher.append("wargaming", "Wargaming Game Center")
+
+    def populate_combobox_with_runtimes(self):
+        self.combobox_runtime.append("umu-host", _("Disable runtime"))
+        self.combobox_runtime.append("umu-scout", _("Scout"))
+        self.combobox_runtime.append("umu-soldier", _("Soldier"))
+        self.combobox_runtime.append("umu-sniper", _("Sniper"))
+        self.combobox_runtime.append("umu-steamrt4", _("SteamRT4"))
 
     def populate_combobox_with_runners(self):
         populate_combobox_with_runners(self.combobox_runner)

--- a/faugus/launcher.py
+++ b/faugus/launcher.py
@@ -4156,7 +4156,7 @@ class Main(Gtk.ApplicationWindow, HiDpiMixin):
                 edit_game_dialog.combobox_launcher.set_active_id_silent("linux")
                 edit_game_dialog.on_combobox_changed(edit_game_dialog.combobox_launcher, skip_cleanup=True)
                 edit_game_dialog.combobox_runtime.set_active_id_silent(
-                    game.runtime or ("disable-runtime" if game.disable_umu else "auto")
+                    game.runtime or ("disable-runtime" if game.disable_umu else "umu-steamrt4")
                 )
             if game_runner == "Steam":
                 edit_game_dialog.combobox_launcher.set_active_id_silent("steam")
@@ -7326,7 +7326,7 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
 
         self.populate_combobox_with_runners()
         self.populate_combobox_with_runtimes()
-        self.combobox_runtime.set_active_id("auto")
+        self.combobox_runtime.set_active_id("umu-steamrt4")
 
         if not self.combobox_runner.set_active_id(self.default_runner):
             self.combobox_runner.set_active(0)
@@ -8114,12 +8114,11 @@ class AddGame(Gtk.Dialog, HiDpiMixin):
         self.combobox_launcher.append("wargaming", "Wargaming Game Center")
 
     def populate_combobox_with_runtimes(self):
-        self.combobox_runtime.append("auto", "{} ({})".format(_("Auto"), _("Default")))
-        self.combobox_runtime.append("disable-runtime", _("Disable Runtime"))
-        self.combobox_runtime.append("umu-steamrt4", _("SteamRT4"))
+        self.combobox_runtime.append("umu-steamrt4", "{} ({})".format(_("SteamRT4"), _("Default")))
         self.combobox_runtime.append("umu-sniper", _("Sniper"))
         self.combobox_runtime.append("umu-soldier", _("Soldier"))
         self.combobox_runtime.append("umu-scout", _("Scout"))
+        self.combobox_runtime.append("disable-runtime", _("Disable Runtime"))
 
     def populate_combobox_with_runners(self):
         populate_combobox_with_runners(self.combobox_runner)

--- a/faugus/runner.py
+++ b/faugus/runner.py
@@ -808,7 +808,7 @@ def build_launch_command(game):
         command_parts.append(f"GAMEID={protonfix}")
     if runner:
         if runner == "Linux-Native":
-            if not disable_umu:
+            if not disable_umu and linux_runtime and linux_runtime != "auto":
                 command_parts.append(f"PROTONPATH={linux_runtime}")
         elif runner == "Proton-CachyOS (System)":
             command_parts.append(f"WINEPREFIX={shlex.quote(prefix)}")

--- a/faugus/runner.py
+++ b/faugus/runner.py
@@ -195,12 +195,12 @@ class FaugusRun(HiDpiMixin):
                             os.remove(f"{target_dir}/{file}")
 
         if not os.environ.get("WINEPREFIX"):
-            if not os.environ.get("PROTONPATH") == "umu-sniper":
+            if not os.environ.get("PROTONPATH") in ["umu-steamrt4", "umu-sniper", "umu-soldier", "umu-scout", "umu-host"]:
                 set_env("WINEPREFIX", f"{self.default_prefix}/default")
                 set_env("PROTONPATH", f"{resolve_protonpath(self.default_runner)}")
 
         protonpath = os.environ.get("PROTONPATH")
-        if protonpath and protonpath != "Proton-GE Latest" and protonpath != "Proton-EM Latest" and protonpath != "Proton-CachyOS Latest" and protonpath != "DW-Proton Latest" and protonpath != "umu-sniper":
+        if protonpath and protonpath not in ["Proton-GE Latest", "Proton-EM Latest", "Proton-CachyOS Latest", "DW-Proton Latest", "umu-steamrt4", "umu-sniper", "umu-soldier", "umu-scout", "umu-host"]:
             if protonpath == "Proton-CachyOS (System)" and not os.path.exists(PROTON_CACHYOS):
                 self.close_splash_window()
                 self.show_error_dialog(protonpath)
@@ -788,6 +788,7 @@ def build_launch_command(game):
     lossless_present = game.get("lossless_present", "")
     icon = game.get("icon", "")
     disable_umu = bool(game.get("disable_umu", "")) and runner == "Linux-Native"
+    linux_runtime = game.get("runtime","")
 
     if gameid == "ea-app":
         path = update_ea_path(prefix)
@@ -808,7 +809,7 @@ def build_launch_command(game):
     if runner:
         if runner == "Linux-Native":
             if not disable_umu:
-                command_parts.append('PROTONPATH=umu-sniper')
+                command_parts.append(f"PROTONPATH={linux_runtime}")
         elif runner == "Proton-CachyOS (System)":
             command_parts.append(f"WINEPREFIX={shlex.quote(prefix)}")
             command_parts.append(f"PROTONPATH={PROTON_CACHYOS}")

--- a/faugus/runner.py
+++ b/faugus/runner.py
@@ -808,7 +808,7 @@ def build_launch_command(game):
         command_parts.append(f"GAMEID={protonfix}")
     if runner:
         if runner == "Linux-Native":
-            if not disable_umu and linux_runtime and linux_runtime != "auto":
+            if not disable_umu and linux_runtime:
                 command_parts.append(f"PROTONPATH={linux_runtime}")
         elif runner == "Proton-CachyOS (System)":
             command_parts.append(f"WINEPREFIX={shlex.quote(prefix)}")

--- a/faugus/utils.py
+++ b/faugus/utils.py
@@ -1157,7 +1157,7 @@ GAME_FIELDS = [
     "lossless_performance", "lossless_hdr", "lossless_present",
     "playtime", "hidden", "no_sleep", "category", "icon",
     "steamgriddb_id", "pre_launch", "post_launch",
-    "steam_user", "disable_umu",
+    "steam_user", "disable_umu", "runtime",
 ]
 
 

--- a/faugus/utils.py
+++ b/faugus/utils.py
@@ -1059,6 +1059,10 @@ def update_games_json():
             game["runner"] = "Proton-CachyOS (System)"
             changed = True
 
+        if game.get("disable_umu") and game.get("runtime") != "disable-runtime":
+            game["runtime"] = "disable-runtime"
+            changed = True
+
         if "favorite" in game:
             if game["favorite"] == True:
                 game["category"] = False


### PR DESCRIPTION
With this MR it's now possible to select desired Steam Linux Runtime for native Linux games (or even disable runtime entirely). It's backwards compatible with existing games and for new games it selects Sniper (steamrt3) by default.
<img width="588" height="733" alt="Снимок экрана_20260903_144137" src="https://github.com/user-attachments/assets/49524446-f5f9-40bc-b49a-21a2102451e8" />

