### PR TITLE
docs: document Ubuntu AppArmor/bwrap workaround for umu (incl. bundled srt-bwrap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,42 @@ sudo apt install -y ~/faugus-launcher/*.deb
 sudo rm -r ~/faugus-launcher
 ```
 
+### Ubuntu 24.04+ / AppArmor (unprivileged user namespaces)
+
+If a `.deb`/PPA install fails with:
+
+```text
+bwrap: setting up uid map: Permission denied
+```
+
+load an AppArmor exception for both system `bwrap` and the `srt-bwrap` bundled by umu:
+
+```bash
+sudo tee /etc/apparmor.d/umu-bwrap > /dev/null <<'EOF'
+abi <abi/4.0>,
+include <tunables/global>
+
+profile umu-bwrap /usr/bin/bwrap flags=(unconfined) {
+  userns,
+  include if exists <local/umu-bwrap>
+}
+
+profile umu-srt-bwrap /home/*/.local/share/umu/steamrt*/pressure-vessel/libexec/steam-runtime-tools-*/srt-bwrap flags=(unconfined) {
+  userns,
+  include if exists <local/umu-srt-bwrap>
+}
+EOF
+sudo apparmor_parser -r /etc/apparmor.d/umu-bwrap
+```
+
+Verify:
+
+```bash
+bwrap --unshare-user --ro-bind / / /bin/true && echo "bwrap OK"
+```
+
+The Flatpak build is unaffected because Flatpak uses its own sandbox path.
+
 ## [Flatpak](https://flathub.org/apps/io.github.Faugus.faugus-launcher)
 ### Installation:
 ```


### PR DESCRIPTION
This adds a short troubleshooting section for Ubuntu 24.04+ `.deb`/PPA users whose install stops at `bwrap: setting up uid map: Permission denied`. The documented profile grants the required `userns` permission to both the system bubblewrap binary and the bubblewrap copy bundled inside umu's Steam Runtime. The goal is to make an existing, repeatedly reported fix discoverable before another issue is filed.

## Why this keeps coming back

| Issue | Date | Title |
| --- | --- | --- |
| #231 | 2025-09-25 | bwrap and apparmor |
| #240 | 2025-10-06 | umu-launcher bwrap error |
| #247 | 2025-10-17 | opening epic game store on ubunutu 24.04.03 |
| #399 | 2026-01-19 | Unable to install Battle.net |

All four were closed by linking the workaround gist. The current 164-line README has no occurrences of `apparmor`, `bwrap`, `userns`, or `namespace`, so users cannot find the fix before opening a duplicate.

## What the current gist misses

The official workaround gist creates an AppArmor profile for `/usr/bin/bwrap` only. During a umu launch, pressure-vessel also invokes the `srt-bwrap` binary bundled in the `steamrt4` runtime. AppArmor matches executable profiles by path, so the bundled binary needs its own profile entry.

With the extended profile loaded, this isolation test produced:

| Test | Command target | Result |
| --- | --- | --- |
| A | `/usr/bin/bwrap --unshare-user --ro-bind / / /bin/true` | PERMITTED |
| B | `<runtime>/steam-runtime-tools-0/srt-bwrap --unshare-user --ro-bind / / /bin/true` at its real path | PERMITTED |
| C | The same `srt-bwrap` binary copied to `/tmp/` and run from there | **DENIED** — `bwrap: setting up uid map: Permission denied` |

Test C is the control: the binary is byte-identical and only its filesystem path changes. That isolates path-based AppArmor matching as the deciding factor.

## Reproduced and verified on

- Ubuntu 24.04.4 LTS, kernel 7.0.0-30-generic, GNOME on Wayland
- faugus-launcher 2.2.1-1 from the `.deb`/PPA
- umu-launcher 1.4.4 with the `steamrt4` runtime
- Proton-CachyOS Latest (`proton-cachyos-10.0-20260425-slr-x86_64`)
- AppArmor parser 4.0.1
- Battle.net installer

The host reported `kernel.apparmor_restrict_unprivileged_userns = 1`, and `unshare --user --map-root-user true` failed while writing `/proc/self/uid_map`. The two-profile file was syntax-checked with `apparmor_parser -Q -d`.

I am happy to adjust the wording, or to drop the `srt-bwrap` profile if you would prefer to keep the gist authoritative. The intent is to improve discoverability while documenting the additional runtime-path case found during verification.
